### PR TITLE
Fix wrong quotation mark handling

### DIFF
--- a/source/electricity-market/ElectricityMarket.Application/Services/CsvImporter.cs
+++ b/source/electricity-market/ElectricityMarket.Application/Services/CsvImporter.cs
@@ -32,7 +32,7 @@ public class CsvImporter : ICsvImporter
             HeaderValidated = null,
             MissingFieldFound = null,
             DetectDelimiter = true,
-            Mode = CsvMode.NoEscape
+            Mode = CsvMode.Escape
         };
         using var csv = new CsvReader(reader, conf);
         var records = csv.GetRecordsAsync<ImportedTransactionRecord>();


### PR DESCRIPTION
Before, if a field contained quotation mark, it was just ignored