### PR TITLE
test: asserts that migrated tables follows schemas defined in geh_common

### DIFF
--- a/source/geh_electricity_market/pyproject.toml
+++ b/source/geh_electricity_market/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "azure-identity>=1.21.0",
     "azure-keyvault-secrets>=4.9.0",
     "azure-monitor-query>=1.4.1",
-    "geh_common @ git+https://git@github.com/Energinet-DataHub/opengeh-python-packages@geh_common_5.7.0#subdirectory=source/geh_common",
+    "geh_common @ git+https://git@github.com/Energinet-DataHub/opengeh-python-packages@geh_common_5.8.5#subdirectory=source/geh_common",
     "pydantic>=2.11.2",
     "pyspark>=3.5.0",
 ]

--- a/source/geh_electricity_market/tests/conftest.py
+++ b/source/geh_electricity_market/tests/conftest.py
@@ -41,12 +41,6 @@ def fix_print():
         yield mock_print
 
 
-@pytest.fixture(scope="session", autouse=True)
-def ensure_schemas_exist(spark: SparkSession) -> None:
-    for db in DATABASE_NAMES:
-        spark.sql(f"CREATE DATABASE IF NOT EXISTS {db}")
-
-
 @pytest.fixture(scope="session")
 def migrations_executed(spark: SparkSession) -> None:
     """Executes all migrations.

--- a/source/geh_electricity_market/tests/test_schema_migration.py
+++ b/source/geh_electricity_market/tests/test_schema_migration.py
@@ -1,0 +1,27 @@
+import pytest
+from geh_common.data_products.electricity_market_measurements_input import (
+    electrical_heating_child_metering_points_v1,
+    electrical_heating_consumption_metering_point_periods_v1,
+    missing_measurements_log_metering_point_periods_v1,
+    net_consumption_group_6_child_metering_points_v1,
+    net_consumption_group_6_consumption_metering_point_periods_v1,
+)
+from geh_common.testing.dataframes.assert_schemas import assert_schema
+
+from tests import SPARK_CATALOG_NAME
+
+
+@pytest.mark.parametrize(
+    "dataproduct",
+    [
+        electrical_heating_child_metering_points_v1,
+        electrical_heating_consumption_metering_point_periods_v1,
+        missing_measurements_log_metering_point_periods_v1,
+        net_consumption_group_6_consumption_metering_point_periods_v1,
+        net_consumption_group_6_child_metering_points_v1,
+    ],
+)
+def test_schema_migration(spark, migrations_executed, dataproduct):
+    fqn = f"{SPARK_CATALOG_NAME}.{dataproduct.database_name}.{dataproduct.view_name}"
+    df = spark.read.table(fqn)
+    assert_schema(df.schema, dataproduct.schema, ignore_column_order=True, ignore_nullability=True)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
