### PR TITLE
1332 implement energy supplier validation rules for signature

### DIFF
--- a/source/electricity-market/ElectricityMarket.Application/Commands/Authorize/GetSupplierPeriodsCommand.cs
+++ b/source/electricity-market/ElectricityMarket.Application/Commands/Authorize/GetSupplierPeriodsCommand.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.ObjectModel;
+using MediatR;
+using NodaTime;
+
+namespace Energinet.DataHub.ElectricityMarket.Application.Commands.Authorize
+{
+    public sealed record GetSupplierPeriodsCommand(string MeteringPointIdentification, string ActorNumber, Interval RequestedPeriod)
+        : IRequest<IEnumerable<Interval>>;
+}

--- a/source/electricity-market/ElectricityMarket.Application/Commands/Authorize/GetSupplierPeriodsCommand.cs
+++ b/source/electricity-market/ElectricityMarket.Application/Commands/Authorize/GetSupplierPeriodsCommand.cs
@@ -16,8 +16,7 @@ using System.Collections.ObjectModel;
 using MediatR;
 using NodaTime;
 
-namespace Energinet.DataHub.ElectricityMarket.Application.Commands.Authorize
-{
-    public sealed record GetSupplierPeriodsCommand(string MeteringPointIdentification, string ActorNumber, Interval RequestedPeriod)
-        : IRequest<IEnumerable<Interval>>;
-}
+namespace Energinet.DataHub.ElectricityMarket.Application.Commands.Authorize;
+
+public sealed record GetSupplierPeriodsCommand(string MeteringPointIdentification, string ActorNumber, Interval RequestedPeriod)
+    : IRequest<IEnumerable<Interval>>;

--- a/source/electricity-market/ElectricityMarket.Application/Handlers/GetSupplierPeriodsHandler.cs
+++ b/source/electricity-market/ElectricityMarket.Application/Handlers/GetSupplierPeriodsHandler.cs
@@ -1,0 +1,78 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.ElectricityMarket.Application.Commands.Authorize;
+using Energinet.DataHub.ElectricityMarket.Domain.Models;
+using Energinet.DataHub.ElectricityMarket.Domain.Repositories;
+using MediatR;
+using NodaTime;
+using static Apache.Arrow.Memory.MemoryAllocator;
+
+namespace Energinet.DataHub.ElectricityMarket.Application.Handlers;
+
+public sealed class GetSupplierPeriodsHandler : IRequestHandler<GetSupplierPeriodsCommand, IEnumerable<Interval>>
+{
+    private readonly IMeteringPointRepository _meteringPointRepository;
+
+    public GetSupplierPeriodsHandler(IMeteringPointRepository meteringPointRepository)
+    {
+        _meteringPointRepository = meteringPointRepository;
+    }
+
+    public async Task<IEnumerable<Interval>> Handle(GetSupplierPeriodsCommand request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request, nameof(request));
+
+        var meteringPoint = await _meteringPointRepository.GetMeteringPointForSignatureAsync(
+           new MeteringPointIdentification(request.MeteringPointIdentification))
+            .ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(meteringPoint, nameof(meteringPoint));
+
+        var commercialRelations = meteringPoint.CommercialRelationTimeline;
+        var energySupplier = request.ActorNumber;
+        var resultPeriods = new List<Interval>();
+        if (commercialRelations != null)
+        {
+            // Retrieve commercial relations where the supplier is related to the metering point
+            var filteredCommercialRelations = commercialRelations.Where(c => (c.EnergySupplier == energySupplier) && (c.Period.Start <= request.RequestedPeriod.End)
+                && (!c.Period.HasEnd || c.Period.End >= request.RequestedPeriod.Start));
+            if (filteredCommercialRelations == null)
+            {
+                return Enumerable.Empty<Interval>();
+            }
+
+            foreach (var relation in filteredCommercialRelations)
+            {
+                // Set the periods before the request start date to the request start date and the periods after the request end date to the request end date (e.g. respect the
+                // request period).
+                var start = relation.Period.Start;
+                var end = relation.Period.End;
+                if (relation.Period.Start < request.RequestedPeriod.Start)
+                {
+                    start = request.RequestedPeriod.Start;
+                }
+
+                if (!relation.Period.HasEnd || relation.Period.End > request.RequestedPeriod.End)
+                {
+                    end = request.RequestedPeriod.End;
+                }
+
+                resultPeriods.Add(new Interval(start, end));
+
+            }
+        }
+
+        return resultPeriods;
+    }
+}

--- a/source/electricity-market/ElectricityMarket.Application/Handlers/GetSupplierPeriodsHandler.cs
+++ b/source/electricity-market/ElectricityMarket.Application/Handlers/GetSupplierPeriodsHandler.cs
@@ -45,6 +45,7 @@ public sealed class GetSupplierPeriodsHandler : IRequestHandler<GetSupplierPerio
         if (commercialRelations != null)
         {
             // Retrieve commercial relations where the supplier is related to the metering point
+            // TODO Question: Why is has end not set to false? Is no end date always max value, or is this only in the mock set up??
             var filteredCommercialRelations = commercialRelations.Where(c => (c.EnergySupplier == energySupplier) && (c.Period.Start <= request.RequestedPeriod.End)
                 && (!c.Period.HasEnd || c.Period.End >= request.RequestedPeriod.Start));
             if (filteredCommercialRelations == null)

--- a/source/electricity-market/ElectricityMarket.DataApi/Functions/Authorize/GetSupplierPeriodsTrigger.cs
+++ b/source/electricity-market/ElectricityMarket.DataApi/Functions/Authorize/GetSupplierPeriodsTrigger.cs
@@ -15,6 +15,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
+using NodaTime;
 
 namespace Energinet.DataHub.ElectricityMarket.Hosts.DataApi.Functions.Authorize
 {

--- a/source/electricity-market/ElectricityMarket.DataApi/Functions/Authorize/GetSupplierPeriodsTrigger.cs
+++ b/source/electricity-market/ElectricityMarket.DataApi/Functions/Authorize/GetSupplierPeriodsTrigger.cs
@@ -1,4 +1,8 @@
-﻿// You may obtain a copy of the License at
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
@@ -31,7 +35,7 @@ namespace Energinet.DataHub.ElectricityMarket.Hosts.DataApi.Functions.Authorize
         [Function(nameof(GetSupplierPeriodsTriggerAsync))]
         [Authorize]
         public async Task<HttpResponseData> GetSupplierPeriodsTriggerAsync(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "get-supplier-periods")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "get-supplier-periods")]
         HttpRequestData req,
         [FromBody] Interval requestedPeriod,
         FunctionContext executionContext)

--- a/source/electricity-market/ElectricityMarket.DataApi/Functions/Authorize/GetSupplierPeriodsTrigger.cs
+++ b/source/electricity-market/ElectricityMarket.DataApi/Functions/Authorize/GetSupplierPeriodsTrigger.cs
@@ -1,0 +1,61 @@
+﻿// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.ObjectModel;
+using System.Net;
+using Energinet.DataHub.ElectricityMarket.Application.Commands.Authorize;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace Energinet.DataHub.ElectricityMarket.Hosts.DataApi.Functions.Authorize
+{
+    internal sealed class GetSupplierPeriodsTrigger
+    {
+        private readonly IMediator _mediator;
+
+        public GetSupplierPeriodsTrigger(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [Function(nameof(GetSupplierPeriodsTriggerAsync))]
+        [Authorize]
+        public async Task<HttpResponseData> GetSupplierPeriodsTriggerAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "get-supplier-periods")]
+        HttpRequestData req,
+        [FromBody] ReadOnlyCollection<Interval> requestedPeriod,
+        FunctionContext executionContext)
+        {
+            var meteringPointId = req.Query["meteringPointId"];
+            var actorNumber = req.Query["actorNumber"];
+            if (string.IsNullOrWhiteSpace(meteringPointId) || string.IsNullOrWhiteSpace(actorNumber))
+            {
+                var badRequestResponse = req.CreateResponse(HttpStatusCode.BadRequest);
+                return badRequestResponse;
+            }
+
+            var command = new GetSupplierPeriodsTrigger(meteringPointId, actorNumber, requestedPeriod);
+
+            var result = await _mediator
+                .Send(command)
+                .ConfigureAwait(false);
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+
+            await response
+                .WriteAsJsonAsync(result)
+                .ConfigureAwait(false);
+
+            return response;
+        }
+    }
+}

--- a/source/electricity-market/ElectricityMarket.DataApi/Functions/Authorize/GetSupplierPeriodsTrigger.cs
+++ b/source/electricity-market/ElectricityMarket.DataApi/Functions/Authorize/GetSupplierPeriodsTrigger.cs
@@ -33,7 +33,7 @@ namespace Energinet.DataHub.ElectricityMarket.Hosts.DataApi.Functions.Authorize
         public async Task<HttpResponseData> GetSupplierPeriodsTriggerAsync(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "get-supplier-periods")]
         HttpRequestData req,
-        [FromBody] ReadOnlyCollection<Interval> requestedPeriod,
+        [FromBody] Interval requestedPeriod,
         FunctionContext executionContext)
         {
             var meteringPointId = req.Query["meteringPointId"];
@@ -44,7 +44,7 @@ namespace Energinet.DataHub.ElectricityMarket.Hosts.DataApi.Functions.Authorize
                 return badRequestResponse;
             }
 
-            var command = new GetSupplierPeriodsTrigger(meteringPointId, actorNumber, requestedPeriod);
+            var command = new GetSupplierPeriodsCommand(meteringPointId, actorNumber, requestedPeriod);
 
             var result = await _mediator
                 .Send(command)

--- a/source/electricity-market/ElectricityMarket.IntegrationTests/Repositories/GetSupplierPeriodsTests.cs
+++ b/source/electricity-market/ElectricityMarket.IntegrationTests/Repositories/GetSupplierPeriodsTests.cs
@@ -1,0 +1,188 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Energinet.DataHub.ElectricityMarket.Application.Commands.Authorize;
+using Energinet.DataHub.ElectricityMarket.Application.Handlers;
+using Energinet.DataHub.ElectricityMarket.Domain.Models;
+using Energinet.DataHub.ElectricityMarket.Infrastructure.Persistence.Model;
+using Energinet.DataHub.ElectricityMarket.Infrastructure.Repositories;
+using Energinet.DataHub.ElectricityMarket.Integration.Models.MasterData;
+using Energinet.DataHub.ElectricityMarket.IntegrationTests.Common;
+using Energinet.DataHub.ElectricityMarket.IntegrationTests.Fixtures;
+using NodaTime;
+using Xunit;
+using ConnectionState = Energinet.DataHub.ElectricityMarket.Domain.Models.ConnectionState;
+using MeteringPointIdentification = Energinet.DataHub.ElectricityMarket.Domain.Models.MeteringPointIdentification;
+using MeteringPointSubType = Energinet.DataHub.ElectricityMarket.Domain.Models.MeteringPointSubType;
+using MeteringPointType = Energinet.DataHub.ElectricityMarket.Domain.Models.MeteringPointType;
+
+namespace Energinet.DataHub.ElectricityMarket.IntegrationTests.Repositories
+{
+    public class GetSupplierPeriodsTests : IClassFixture<ElectricityMarketDatabaseContextFixture>, IAsyncLifetime
+    {
+        private readonly ElectricityMarketDatabaseContextFixture _fixture;
+        private readonly int _startDateOffset1 = -90;
+        private readonly int _endDateOffset1 = -30;
+        private readonly string _balanceSupplier1 = "12345678";
+        private readonly int _startDateOffset2 = -10;
+        private readonly int _startDateOffset3 = -200;
+        private readonly int _endDateOffset3 = -150;
+        private readonly Instant _today = Instant.FromDateTimeUtc(DateTime.Today.ToUniversalTime());
+        private readonly DateTimeOffset _todayDateTime = DateTime.Today.ToUniversalTime();
+
+
+        public GetSupplierPeriodsTests(ElectricityMarketDatabaseContextFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task GetSupplierPeriodsTest()
+        {
+            // arrange
+            var parentIdentification = await CreateTestDataAsync();
+
+            var dbContext = _fixture.DatabaseManager.CreateDbContext();
+            await using var electricityMarketDatabaseContext = dbContext;
+
+            var sut = new MeteringPointRepository(null!, dbContext, null!, null!);
+            var res = await sut.GetMeteringPointForSignatureAsync(parentIdentification);
+
+            Assert.NotNull(res);
+
+            // act + assert 2 periods from 3 should be returned.
+            var target = new GetSupplierPeriodsHandler(sut);
+
+            var requestPeriod = new Interval(Instant.FromDateTimeUtc(DateTime.UtcNow.AddDays(-100)), Instant.FromDateTimeUtc(DateTime.UtcNow.AddDays(-1)));
+            var command = new GetSupplierPeriodsCommand(res.Identification.Value.ToString(CultureInfo.InvariantCulture), _balanceSupplier1, requestPeriod);
+            var response = await target.Handle(command, CancellationToken.None);
+
+            Assert.NotNull(response);
+            Assert.Equal(2, response.Count());
+
+            // act + assert 3 periods from 3 should be returned.
+            requestPeriod = new Interval(Instant.FromDateTimeUtc(DateTime.UtcNow.AddDays(-400)), Instant.FromDateTimeUtc(DateTime.UtcNow));
+            command = new GetSupplierPeriodsCommand(res.Identification.Value.ToString(CultureInfo.InvariantCulture), _balanceSupplier1, requestPeriod);
+            response = await target.Handle(command, CancellationToken.None);
+
+            Assert.NotNull(response);
+            Assert.Equal(3, response.Count());
+
+            // act + assert 1 period from 3 should be returned.
+            // This period should match requested end date (=-5 from today). No end date (max value) in commercial relation.
+            // Start date should match commercial relation start date, which is more recent than requested start date
+            requestPeriod = new Interval(_today.Minus(Duration.FromDays(15)), _today.Minus(Duration.FromDays(5)));
+            command = new GetSupplierPeriodsCommand(res.Identification.Value.ToString(CultureInfo.InvariantCulture), _balanceSupplier1, requestPeriod);
+            response = await target.Handle(command, CancellationToken.None);
+            Assert.NotNull(response);
+            Assert.Single(response);
+
+            Assert.Equal(_today.Minus(Duration.FromDays(10)), response.First().Start);
+            Assert.Equal(_today.Minus(Duration.FromDays(5)), response.First().End);
+
+
+            // act + assert 1 period from 3 should be returned.
+            // This period should match requested end date (=-5 from today). No end date (max value) in commercial relation.
+            // Start date should match the requested start date because the commercial relation start date is earlier.
+            requestPeriod = new Interval(_today.Minus(Duration.FromDays(8)), _today.Minus(Duration.FromDays(5)));
+            command = new GetSupplierPeriodsCommand(res.Identification.Value.ToString(CultureInfo.InvariantCulture), _balanceSupplier1, requestPeriod);
+            response = await target.Handle(command, CancellationToken.None);
+            Assert.NotNull(response);
+            Assert.Single(response);
+
+            Assert.Equal(_today.Minus(Duration.FromDays(8)), response.First().Start);
+            Assert.Equal(_today.Minus(Duration.FromDays(5)), response.First().End);
+
+            // act + assert no results because incorrect balance supplier.
+            requestPeriod = new Interval(_today.Minus(Duration.FromDays(15)), _today.Minus(Duration.FromDays(5)));
+            command = new GetSupplierPeriodsCommand(res.Identification.Value.ToString(CultureInfo.InvariantCulture), "00000001", requestPeriod);
+            response = await target.Handle(command, CancellationToken.None);
+            Assert.Empty(response);
+        }
+
+        public Task InitializeAsync() => _fixture.InitializeAsync();
+
+        public Task DisposeAsync() => _fixture.DisposeAsync();
+
+        private async Task<MeteringPointIdentification> CreateTestDataAsync()
+        {
+            await using var dbContext = _fixture.DatabaseManager.CreateDbContext();
+
+            // Parent metering point
+            var parentIdentification = Some.MeteringPointIdentification();
+            var installationAddress = Some.InstallationAddressEntity();
+            await dbContext.InstallationAddresses.AddAsync(installationAddress);
+            var meteringPointPeriodEntity = new MeteringPointPeriodEntity()
+            {
+                ValidFrom = DateTimeOffset.Now.AddDays(-1),
+                ValidTo = DateTimeOffset.Now.AddDays(2),
+                CreatedAt = DateTimeOffset.Now,
+                GridAreaCode = "001",
+                OwnedBy = "4672928796219",
+                ConnectionState = ConnectionState.Connected.ToString(),
+                Type = MeteringPointType.Consumption.ToString(),
+                SubType = MeteringPointSubType.Physical.ToString(),
+                Resolution = "PT15M",
+                ScheduledMeterReadingMonth = 1,
+                MeteringPointStateId = 1,
+                MeasureUnit = MeasureUnit.kWh.ToString(),
+                Product = Product.EnergyActive.ToString(),
+                TransactionType = "CREATEMP",
+                InstallationAddress = installationAddress
+            };
+            var commercialRelationEntity1 = new CommercialRelationEntity()
+            {
+                StartDate = _todayDateTime.AddDays(_startDateOffset1),
+                EndDate = _todayDateTime.AddDays(_endDateOffset1),
+                EnergySupplier = _balanceSupplier1,
+                MeteringPointId = parentIdentification.Value
+            };
+
+            // No endate
+            var commercialRelationEntity2 = new CommercialRelationEntity()
+            {
+                StartDate = _todayDateTime.AddDays(_startDateOffset2),
+                EndDate = DateTimeOffset.MaxValue,
+                EnergySupplier = _balanceSupplier1,
+                MeteringPointId = parentIdentification.Value
+            };
+            var commercialRelationEntity3 = new CommercialRelationEntity()
+            {
+                StartDate = _todayDateTime.AddDays(_startDateOffset3),
+                EndDate = _todayDateTime.AddDays(_endDateOffset3),
+                EnergySupplier = _balanceSupplier1,
+                MeteringPointId = parentIdentification.Value
+            };
+            await dbContext.MeteringPointPeriods.AddAsync(meteringPointPeriodEntity);
+            await dbContext.CommercialRelations.AddAsync(commercialRelationEntity1);
+            await dbContext.CommercialRelations.AddAsync(commercialRelationEntity2);
+            await dbContext.CommercialRelations.AddAsync(commercialRelationEntity3);
+            await dbContext.MeteringPoints.AddAsync(new MeteringPointEntity()
+            {
+                Identification = parentIdentification.Value,
+                MeteringPointPeriods = { meteringPointPeriodEntity },
+                CommercialRelations = { commercialRelationEntity1, commercialRelationEntity2, commercialRelationEntity3 }
+            });
+
+            await dbContext.SaveChangesAsync();
+            return parentIdentification;
+        }
+    }
+}


### PR DESCRIPTION
Implemented logic for returning the periods where a supplier has access to the measurement data. The periods are filtered to the requested date range.

Note:. Code is prepared that commercial relation periods can have an end date that is empty/null. We are not sure if this possible. For the tests we had to enter max value for the end date to get the commercial relations with no end date / far in the future.

See also the comment/question in ..\geh-electricity-market\source\electricity-market\ElectricityMarket.Application\Handlers\GetSupplierPeriodsHandler.cs